### PR TITLE
Makefile logic refactor

### DIFF
--- a/.make/make.sh
+++ b/.make/make.sh
@@ -2,15 +2,54 @@
 set -eu
 
 
+# LOG_SEPARATOR used to friendly output blocks separation.
+LOG_SEPARATOR='================================================================================'
+
+
+# make_install_by_package_manager will try to install the `make` program using a well-known package manager.
+make_install_by_package_manager()
+{
+	if [ -x "$(command -v apk)" ]
+	then
+		# Alpine based environments.
+		apk add make
+	elif [ -x "$(command -v apt-get)" ]
+	then
+		# Ubuntu and debian based environments.
+		apt-get -qq update
+		apt-get -qq install -y make
+	elif [ -x "$(command -v yum)" ]
+	then
+		# Redhat based environments.
+		yum -q install -y make
+	else
+		echo '`make` cannot be installed in current environment.'
+		exit 1
+	fi
+}
+
+
 # The only target cannot be resolved by make - GNUmake itself.
 # Main idea - we dont know where `make` session was invoked.
 # Maybe there is not GNUmake installed. Detect system, package manager and install it.
 if ! [ -x "$(command -v make)" ]
 then
-	# https://unix.stackexchange.com/questions/46081/identifying-the-system-package-manager
-	echo 'make AUTO INSTALL NOT IMPLEMENTED. COMING SOON.'
-	exit 1
+	# We will detect package managers only.
+	# If no package manager installed we would compile gnumake.
+	# But it is too far...
+	echo ${LOG_SEPARATOR}
+	echo 'Autoinstall data:'
+	make_install_by_package_manager
 fi
+
+
+echo ${LOG_SEPARATOR}
+make --version
+echo ${LOG_SEPARATOR}
+# Selftest block. Can we use current make in proper way?
+echo 'Selftest (look at root Makefile `selftest` target):'
+make selftest
+echo ${LOG_SEPARATOR}
 
 
 # Get required variables for running make session from caller.
@@ -18,10 +57,5 @@ readonly DIFF
 readonly DIFF_MOD
 
 
-echo '================================================================================'
-make --version
-echo '================================================================================'
-
-
-# Make installed, just forward request to his binary.
+# Make installed, version is compatible, just forward request to his binary.
 make DIFF_MOD="${DIFF_MOD}" DIFF="${DIFF}" $@

--- a/.make/make.sh
+++ b/.make/make.sh
@@ -29,6 +29,7 @@ make_install_by_package_manager()
 }
 
 
+# Phase 1. We need `GNUmake`.
 # The only target cannot be resolved by make - GNUmake itself.
 # Main idea - we dont know where `make` session was invoked.
 # Maybe there is not GNUmake installed. Detect system, package manager and install it.
@@ -43,13 +44,15 @@ then
 fi
 
 
+# Phase 2. Print information about installed `GNUmake`.
 echo ${LOG_SEPARATOR}
 make --version
+
+
+# Phase 3. Selftest block. Can we use current make in proper way?
 echo ${LOG_SEPARATOR}
-# Selftest block. Can we use current make in proper way?
 echo 'Selftest (look at root Makefile `selftest` target):'
 make selftest
-echo ${LOG_SEPARATOR}
 
 
 # Get required variables for running make session from caller.
@@ -57,5 +60,7 @@ readonly DIFF
 readonly DIFF_MOD
 
 
+# Phase 4. Doing main job.
 # Make installed, version is compatible, just forward request to his binary.
+echo ${LOG_SEPARATOR}
 make DIFF_MOD="${DIFF_MOD}" DIFF="${DIFF}" $@

--- a/.make/terraform.mk
+++ b/.make/terraform.mk
@@ -7,7 +7,7 @@ TERRAFORM := $(shell which terraform)
 ifeq ($(TERRAFORM),)
 	# Case when bainary is not installed. We have target below for installing stable version.
 	TERRAFORM := $(HOME)/bin/terraform
-	TERRAFORM_VERSION := 0.12.12
+	TERRAFORM_VERSION := 0.12.15
 	TERRAFORM_RELEASE_LINK := https://releases.hashicorp.com/terraform/$(TERRAFORM_VERSION)/terraform_$(TERRAFORM_VERSION)_linux_amd64.zip
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ FORMAT_ROOTS = $(sort \
 define SHELL_SORT_REVERSE_BY_LEN
 	echo '$(1)' | \
 	xargs -n1 | \
-	awk '{ print length, $$0 }' | \
+	awk '{ print length($$0), $$0 }' | \
 	sort -rn | \
 	cut -d' ' -f2- | \
 	xargs


### PR DESCRIPTION
- Fix awk in SHELL_SORT_REVERSE_BY_LEN
- Feat: make autoinstall by package manager

Tested on images:
- ubuntu
- centos
- atlassian/pipelines-awscli
- macos

Now make.sh have 4 Phases:
1) Check does it need to install gnumake
2) Log information about existing or installed gnumake
3) Run Makefile's tests (selftest target)
4) Proxy request to gnumake